### PR TITLE
Add Spanish localization with auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ class FreeUForForge(scripts.Script):
 
 See also [Forge's Unet Implementation](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/main/backend/nn/unet.py).
 
+# Internationalization
+
+Forge can display the interface in multiple languages. Translation files are loaded from the
+`localizations/` directory on startup. Each file should be a JSON map of English text to its
+translation. A sample Spanish translation is included as `localizations/es.json`.
+
+If the `WEBUI_LANG` or system `LANG` environment variable matches an available language name
+(for example `es`), that localization will be selected automatically at launch. The language can
+also be changed later in **Settings → User interface → Localization**.
+
+To create your own translation open the Settings tab and click **Download localization template**,
+translate the resulting file and place it under `localizations/`.
+
 # Under Construction
 
 WebUI Forge is now under some constructions, and docs / UI / functionality may change with updates.

--- a/localizations/es.json
+++ b/localizations/es.json
@@ -1,0 +1,20 @@
+{
+    "Txt2img": "Texto a Imagen",
+    "Img2img": "Imagen a Imagen",
+    "Spaces": "Espacios",
+    "Extras": "Extras",
+    "PNG Info": "Información PNG",
+    "Checkpoint Merger": "Combinador de Checkpoints",
+    "Settings": "Configuración",
+    "Extensions": "Extensiones",
+    "Generate": "Generar",
+    "Interrupt": "Interrumpir",
+    "Skip": "Saltar",
+    "Interrupting...": "Interrumpiendo...",
+    "Open for Settings": "Abrir Configuraciones",
+    "Width": "Ancho",
+    "Height": "Alto",
+    "Batch count": "Conteo de lotes",
+    "Batch size": "Tamaño de lote",
+    "CFG Scale": "Escala CFG"
+}

--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -96,9 +96,12 @@ def initialize_rest(*, reload_script_modules=False):
     sd_models.list_models()
     startup_timer.record("list SD models")
 
-    from modules import localization
+    from modules import localization, shared
     localization.list_localizations(cmd_opts.localizations_dir)
     startup_timer.record("list localizations")
+    detected_loc = localization.detect_default_localization()
+    if shared.opts.localization == "None" and detected_loc != "None":
+        shared.opts.localization = detected_loc
 
     with startup_timer.subcategory("load scripts"):
         scripts.load_scripts()

--- a/modules/localization.py
+++ b/modules/localization.py
@@ -6,6 +6,23 @@ from modules import errors, scripts
 localizations = {}
 
 
+def detect_default_localization() -> str:
+    """Detect preferred localization from environment variables."""
+    lang = os.getenv("WEBUI_LANG") or os.getenv("LANG") or ""
+    lang = lang.split('.')[0]
+    if not lang:
+        return "None"
+
+    if lang in localizations:
+        return lang
+
+    base = lang.split('_')[0]
+    if base in localizations:
+        return base
+
+    return "None"
+
+
 def list_localizations(dirname):
     localizations.clear()
 


### PR DESCRIPTION
## Summary
- add Spanish `es.json` translation file
- load language automatically from `WEBUI_LANG`/`LANG`
- document translation support in README

## Testing
- `ruff check .` *(fails: 2617 errors)*
- `pytest -q` *(fails: ImportError and ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840dcfa213c832b80e260151fe84ec4