### PR TITLE
Add simple CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_versions.txt
+          pip install ruff pytest
+      - name: Run Ruff
+        run: ruff check .
+      - name: Run Pytest
+        run: pytest


### PR DESCRIPTION
## Summary
- add CI workflow that installs Python 3.9
- install dependencies and run ruff + pytest

## Testing
- `ruff check .` *(fails: E722 Do not use bare except)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'modules')*

------
https://chatgpt.com/codex/tasks/task_e_6840dcf03de4832b983669e8a6dfe266