### PR TITLE
Implement model prefetch cache

### DIFF
--- a/backend/model_cache.py
+++ b/backend/model_cache.py
@@ -1,0 +1,50 @@
+import threading
+from queue import Queue
+from backend import memory_management
+
+
+_load_queue = Queue()
+_loaded = set()
+_status = ""
+_lock = threading.Lock()
+
+
+def _worker():
+    global _status
+    while True:
+        model = _load_queue.get()
+        if model is None:
+            break
+        name = getattr(model, "__class__", type(model)).__name__
+        _status = f"Prefetching {name}"
+        try:
+            memory_management.load_model_gpu(model)
+            with _lock:
+                _loaded.add(model)
+            _status = f"Prefetched {name}"
+        except Exception as e:
+            _status = f"Prefetch failed: {e}"
+        finally:
+            _load_queue.task_done()
+
+
+_thread = threading.Thread(target=_worker, daemon=True)
+_thread.start()
+
+
+def prefetch_model(model):
+    with _lock:
+        if model in _loaded or model in list(_load_queue.queue):
+            return
+    _load_queue.put(model)
+
+
+def release_model(model):
+    with _lock:
+        if model in _loaded:
+            memory_management.unload_model_clones(model)
+            _loaded.discard(model)
+
+
+def get_status():
+    return _status

--- a/modules/progress.py
+++ b/modules/progress.py
@@ -76,6 +76,7 @@ class ProgressResponse(BaseModel):
 
 def setup_progress_api(app):
     app.add_api_route("/internal/pending-tasks", get_pending_tasks, methods=["GET"])
+    app.add_api_route("/internal/model-cache-status", model_cache_status, methods=["GET"])
     return app.add_api_route("/internal/progress", progressapi, methods=["POST"], response_model=ProgressResponse)
 
 
@@ -140,6 +141,11 @@ def progressapi(req: ProgressRequest):
                 id_live_preview = shared.state.id_live_preview
 
     return ProgressResponse(active=active, queued=queued, completed=completed, progress=progress, eta=eta, live_preview=live_preview, id_live_preview=id_live_preview, textinfo=shared.state.textinfo)
+
+
+def model_cache_status():
+    from backend import model_cache
+    return {"status": model_cache.get_status()}
 
 
 def restore_progress(id_task):

--- a/modules/ui_toprow.py
+++ b/modules/ui_toprow.py
@@ -30,6 +30,7 @@ class Toprow:
     token_button = None
     negative_token_counter = None
     negative_token_button = None
+    model_cache_status = None
 
     ui_styles = None
 
@@ -131,6 +132,7 @@ class Toprow:
             self.token_button = gr.Button(visible=False, elem_id=f"{self.id_part}_token_button")
             self.negative_token_counter = gr.HTML(value="<span>0/75</span>", elem_id=f"{self.id_part}_negative_token_counter", elem_classes=["token-counter"], visible=False)
             self.negative_token_button = gr.Button(visible=False, elem_id=f"{self.id_part}_negative_token_button")
+            self.model_cache_status = gr.HTML("", elem_id=f"{self.id_part}_model_cache_status")
 
             self.clear_prompt_button.click(
                 fn=lambda *x: x,

--- a/modules_forge/diffusers_patcher.py
+++ b/modules_forge/diffusers_patcher.py
@@ -1,5 +1,5 @@
 import torch
-from backend import operations, memory_management
+from backend import operations, memory_management, model_cache
 from backend.patcher.base import ModelPatcher
 
 from transformers import modeling_utils
@@ -38,6 +38,7 @@ class DiffusersModelPatcher:
             offload_device=offload_device)
 
     def prepare_memory_before_sampling(self, batchsize, latent_width, latent_height):
+        model_cache.prefetch_model(self.patcher)
         area = 2 * batchsize * latent_width * latent_height
         inference_memory = (((area * 0.6) / 0.9) + 1024) * (1024 * 1024)
         memory_management.load_models_gpu(

--- a/script.js
+++ b/script.js
@@ -212,3 +212,17 @@ function uiElementInSight(el) {
 
     return isOnScreen;
 }
+
+function requestModelCacheStatus(el) {
+    if (!el) return;
+    fetch('./internal/model-cache-status')
+        .then(res => res.json())
+        .then(data => { el.innerHTML = data.status || ''; })
+        .catch(() => {})
+        .finally(() => { setTimeout(() => requestModelCacheStatus(el), 2000); });
+}
+
+onUiLoaded(function(){
+    requestModelCacheStatus(gradioApp().querySelector('#txt2img_model_cache_status'));
+    requestModelCacheStatus(gradioApp().querySelector('#img2img_model_cache_status'));
+});


### PR DESCRIPTION
## Summary
- add new `backend/model_cache.py` with thread-based prefetch queue
- invoke `model_cache.prefetch_model` before loading diffusers models
- expose prefetch status via API and display in UI

## Testing
- `ruff check backend/model_cache.py modules_forge/diffusers_patcher.py modules/ui_toprow.py modules/progress.py webui.py`


------
https://chatgpt.com/codex/tasks/task_e_6840dcb62608832b99cd3aaa324f46d5