### PR TITLE
Enable multi‑GPU model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ class FreeUForForge(scripts.Script):
 
 See also [Forge's Unet Implementation](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/main/backend/nn/unet.py).
 
+### Multi-GPU mode
+
+When several GPUs are available Forge will automatically load models on the device with the most free memory. Use the command line option `--gpu-device-id` or the `CUDA_VISIBLE_DEVICES` environment variable to limit the GPUs visible to Forge. Functions such as `load_models_gpu()` also accept a `device` argument to manually choose the target GPU.
+
 # Under Construction
 
 WebUI Forge is now under some constructions, and docs / UI / functionality may change with updates.

--- a/extensions-builtin/sd_forge_fooocus_inpaint/scripts/forge_fooocus_inpaint.py
+++ b/extensions-builtin/sd_forge_fooocus_inpaint/scripts/forge_fooocus_inpaint.py
@@ -12,7 +12,11 @@ from backend.patcher.lora import model_lora_keys_unet
 
 
 def is_model_loaded(model):
-    return any(model == m.model for m in current_loaded_models)
+    for models in current_loaded_models.values():
+        for m in models:
+            if model == m.model:
+                return True
+    return False
 
 
 class InpaintHead(torch.nn.Module):

--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -137,7 +137,10 @@ class InterrogateModels:
             self.clip_model = self.clip_model.to(device=self.offload_device, dtype=self.dtype)
             self.clip_patcher = ModelPatcher(self.clip_model, load_device=self.load_device, offload_device=self.offload_device)
 
-        memory_management.load_models_gpu([self.blip_patcher, self.clip_patcher])
+        memory_management.load_models_gpu([
+            self.blip_patcher,
+            self.clip_patcher
+        ], device=self.load_device)
         return
 
     def send_clip_to_ram(self):

--- a/modules_forge/diffusers_patcher.py
+++ b/modules_forge/diffusers_patcher.py
@@ -42,6 +42,7 @@ class DiffusersModelPatcher:
         inference_memory = (((area * 0.6) / 0.9) + 1024) * (1024 * 1024)
         memory_management.load_models_gpu(
             models=[self.patcher],
+            device=self.patcher.load_device,
             memory_required=inference_memory
         )
 


### PR DESCRIPTION
## Summary
- expose list of detected CUDA devices via `available_devices`
- track loaded models per device
- pick GPU with most free memory in `load_models_gpu` when no device supplied
- update callers to pass device
- document multi-GPU usage

## Testing
- `pytest -q` *(fails: ImportError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840dcb3f978832bba15b472859cc2c0