### PR TITLE
Add roundtrip test for face restoration utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,4 @@ extend-immutable-calls = ["fastapi.Depends", "fastapi.security.HTTPBasic"]
 
 [tool.pytest.ini_options]
 base_url = "http://127.0.0.1:7860"
+testpaths = ["tests"]

--- a/tests/test_face_restoration_utils.py
+++ b/tests/test_face_restoration_utils.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+
+import numpy as np
+import torch
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+
+# Create stub modules required by face_restoration_utils
+for name in ["devices", "errors", "face_restoration", "shared"]:
+    mod = types.ModuleType(name)
+    if name == "face_restoration":
+        class FaceRestoration:
+            pass
+        mod.FaceRestoration = FaceRestoration
+    sys.modules.setdefault(f"modules.{name}", mod)
+
+# Stub modules_forge.utils with a dummy prepare_free_memory
+mf_utils = types.ModuleType("modules_forge.utils")
+mf_utils.prepare_free_memory = lambda *_, **__: None
+sys.modules.setdefault("modules_forge.utils", mf_utils)
+
+from modules.face_restoration_utils import bgr_image_to_rgb_tensor, rgb_tensor_to_bgr_image
+
+
+def test_bgr_to_tensor_roundtrip():
+    np.random.seed(0)
+    img = np.random.rand(4, 5, 3).astype(np.float32)
+    tensor = bgr_image_to_rgb_tensor(img)
+    assert isinstance(tensor, torch.Tensor)
+    out = rgb_tensor_to_bgr_image(tensor)
+    assert np.allclose(out, img, atol=1e-6)


### PR DESCRIPTION
## Summary
- add tests for `bgr_image_to_rgb_tensor` and `rgb_tensor_to_bgr_image`
- restrict pytest discovery to the `tests` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d43c9538832ba378771407579c94