### PR TITLE
Fix separator key in gguf constants

### DIFF
--- a/packages_3rdparty/gguf/constants.py
+++ b/packages_3rdparty/gguf/constants.py
@@ -142,7 +142,7 @@ class Keys:
         BOS_ID               = "tokenizer.ggml.bos_token_id"
         EOS_ID               = "tokenizer.ggml.eos_token_id"
         UNK_ID               = "tokenizer.ggml.unknown_token_id"
-        SEP_ID               = "tokenizer.ggml.seperator_token_id"
+        SEP_ID               = "tokenizer.ggml.separator_token_id"
         PAD_ID               = "tokenizer.ggml.padding_token_id"
         CLS_ID               = "tokenizer.ggml.cls_token_id"
         MASK_ID              = "tokenizer.ggml.mask_token_id"


### PR DESCRIPTION
## Summary
- fix a typo in `packages_3rdparty/gguf/constants.py` for the separator token key
- ran existing tests (they failed due to missing modules)

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'modules')*

------
https://chatgpt.com/codex/tasks/task_e_6840d43b03c8832b9abe34b25867dbdb