### PR TITLE
Fix README typo in GPU weight section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ News are moved to this link: [Click here to see the News section](https://github
 
 [(Policy) Soft Advertisement Removal Policy](https://github.com/lllyasviel/stable-diffusion-webui-forge/discussions/1286)
 
-(Flux BNB NF4 / GGUF Q8_0/Q5_0/Q5_1/Q4_0/Q4_1 are all natively supported with GPU weight slider and Quene/Async Swap toggle and swap location toggle. All Flux BNB NF4 / GGUF Q8_0/Q5_0/Q4_0 have LoRA support.)
+(Flux BNB NF4 / GGUF Q8_0/Q5_0/Q5_1/Q4_0/Q4_1 are all natively supported with GPU weight slider and Queue/Async Swap toggle and swap location toggle. All Flux BNB NF4 / GGUF Q8_0/Q5_0/Q4_0 have LoRA support.)
 
 # Installing Forge
 


### PR DESCRIPTION
## Summary
- fix typo "Quene" -> "Queue" in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6840d4221de0832bbce956281cdeb0a0