### PR TITLE
Add simple UI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ News are moved to this link: [Click here to see the News section](https://github
 
 [Tell us what is missing in ControlNet Integrated](https://github.com/lllyasviel/stable-diffusion-webui-forge/discussions/932)
 
+Simple UI mode toggle available in **Settings > UI alternatives** for a Foocus-like minimal interface.
+
 [(Policy) Soft Advertisement Removal Policy](https://github.com/lllyasviel/stable-diffusion-webui-forge/discussions/1286)
 
 (Flux BNB NF4 / GGUF Q8_0/Q5_0/Q5_1/Q4_0/Q4_1 are all natively supported with GPU weight slider and Queue/Async Swap toggle and swap location toggle. All Flux BNB NF4 / GGUF Q8_0/Q5_0/Q4_0 have LoRA support.)

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -325,6 +325,7 @@ options_templates.update(options_section(('ui_gallery', "Gallery", "ui"), {
 
 options_templates.update(options_section(('ui_alternatives', "UI alternatives", "ui"), {
     "compact_prompt_box": OptionInfo(False, "Compact prompt layout").info("puts prompt and negative prompt inside the Generate tab, leaving more vertical space for the image on the right").needs_reload_ui(),
+    "simple_ui_mode": OptionInfo(False, "Simple UI mode").info("show a simplified interface similar to Foocus").needs_reload_ui(),
     "samplers_in_dropdown": OptionInfo(True, "Use dropdown for sampler selection instead of radio group").needs_reload_ui(),
     "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row").needs_reload_ui(),
     "sd_checkpoint_dropdown_use_short": OptionInfo(False, "Checkpoint dropdown: use filenames without paths").info("models in subdirectories like photo/sd15.ckpt will be listed as just sd15.ckpt"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -251,8 +251,13 @@ def create_output_panel(tabname, outdir, toprow=None):
 
 def ordered_ui_categories():
     user_order = {x.strip(): i * 2 + 1 for i, x in enumerate(shared.opts.ui_reorder_list)}
+    categories = list(shared_items.ui_reorder_categories())
 
-    for _, category in sorted(enumerate(shared_items.ui_reorder_categories()), key=lambda x: user_order.get(x[1], x[0] * 2 + 0)):
+    if shared.opts.simple_ui_mode:
+        simple_list = ["prompt", "image", "sampler", "dimensions", "cfg", "seed", "batch"]
+        categories = [c for c in categories if c in simple_list]
+
+    for _, category in sorted(enumerate(categories), key=lambda x: user_order.get(x[1], x[0] * 2 + 0)):
         yield category
 
 

--- a/modules/ui_toprow.py
+++ b/modules/ui_toprow.py
@@ -58,7 +58,8 @@ class Toprow:
 
             self.create_tools_row()
 
-            self.create_styles_ui()
+            if not shared.opts.simple_ui_mode:
+                self.create_styles_ui()
 
     def create_inline_toprow_prompts(self):
         if not self.is_compact:
@@ -69,8 +70,9 @@ class Toprow:
         with gr.Row(elem_classes=["toprow-compact-stylerow"]):
             with gr.Column(elem_classes=["toprow-compact-tools"]):
                 self.create_tools_row()
-            with gr.Column():
-                self.create_styles_ui()
+            if not shared.opts.simple_ui_mode:
+                with gr.Column():
+                    self.create_styles_ui()
 
     def create_inline_toprow_image(self):
         if not self.is_compact:


### PR DESCRIPTION
## Summary
- add `simple_ui_mode` option under UI alternatives
- hide most advanced elements when simple mode is enabled
- document the setting in the readme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e8adfbd0832b8349c7ddd8442319