### PR TITLE
Enable simple UI by default

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -325,7 +325,8 @@ options_templates.update(options_section(('ui_gallery', "Gallery", "ui"), {
 
 options_templates.update(options_section(('ui_alternatives', "UI alternatives", "ui"), {
     "compact_prompt_box": OptionInfo(False, "Compact prompt layout").info("puts prompt and negative prompt inside the Generate tab, leaving more vertical space for the image on the right").needs_reload_ui(),
-    "simple_ui_mode": OptionInfo(False, "Simple UI mode").info("show a simplified interface similar to Foocus").needs_reload_ui(),
+    # Enable simple UI by default so the simplified interface is always available
+    "simple_ui_mode": OptionInfo(True, "Simple UI mode").info("show a simplified interface similar to Foocus").needs_reload_ui(),
     "samplers_in_dropdown": OptionInfo(True, "Use dropdown for sampler selection instead of radio group").needs_reload_ui(),
     "dimensions_and_batch_together": OptionInfo(True, "Show Width/Height and Batch sliders in same row").needs_reload_ui(),
     "sd_checkpoint_dropdown_use_short": OptionInfo(False, "Checkpoint dropdown: use filenames without paths").info("models in subdirectories like photo/sd15.ckpt will be listed as just sd15.ckpt"),


### PR DESCRIPTION
## Summary
- make simplified interface active by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f998fb88832b80cb2d9101d67db0