### PR TITLE
Fix prompt_style_system import error

### DIFF
--- a/modules/prompt_style_system.py
+++ b/modules/prompt_style_system.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Compatibility wrappers for prompt style functions.
+
+This module exposes the API expected by older code that imports
+``modules.prompt_style_system``. The actual implementations live in
+``modules.styles`` and the shared :data:`modules.shared.prompt_styles`
+instance.
+"""
+
+from modules.styles import (
+    PromptStyle,
+    StyleDatabase,
+    apply_styles_to_prompt,
+    extract_style_text_from_prompt,
+    extract_original_prompts,
+)
+from modules import shared
+
+
+def apply_negative_styles_to_prompt(prompt: str, styles: list[str]) -> str:
+    """Apply negative style texts to ``prompt`` using the shared
+    :class:`~modules.styles.StyleDatabase`.
+    """
+    if shared.prompt_styles is None:
+        # Lazily create database if not initialized
+        shared.prompt_styles = StyleDatabase(shared.styles_filename)
+    return shared.prompt_styles.apply_negative_styles_to_prompt(prompt, styles)
+


### PR DESCRIPTION
## Summary
- provide `modules/prompt_style_system.py` with compatibility wrappers for applying prompt styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6849dbff52b8832bbf6e9267cd57c2ea