### PR TITLE
Add button to download last generated image

### DIFF
--- a/style.css
+++ b/style.css
@@ -1703,3 +1703,7 @@ body.resizing .resize-handle {
 .forge_space_btn{
     min-width: 0 !important;
 }
+
+#txt2img_download_button{
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- import default_output_dir and add helper to find the latest generated image
- add a download button after the upscaler row in txt2img settings
- style the button to take the full row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2e5e6228832b87c173e87c813d2a